### PR TITLE
remove error name 'zeros' is not defined

### DIFF
--- a/VoiceAssistant/wakeword/scripts/create_wakeword_json.py
+++ b/VoiceAssistant/wakeword/scripts/create_wakeword_json.py
@@ -10,7 +10,7 @@ import random
 
 
 def main(args):
-    zeroes = os.listdir(args.zero_label_dir)
+    zeros = os.listdir(args.zero_label_dir)
     ones = os.listdir(args.one_label_dir)
 
     data = []


### PR DESCRIPTION
remove error name 'zeros' is not defined by changing name zeroes into zeros in "A-Hackers-AI-Voice-Assistant\VoiceAssistant\wakeword\scripts\create_wakeword_json.py" file.
![Screenshot 2020-09-27 194324](https://user-images.githubusercontent.com/48671623/94367104-13dce600-00fa-11eb-96d1-edf7b4a37128.png)
