### PR TITLE
README.md no longer has a typographical error in the virtualenv secti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ TODO:
 If you're on mac you can install `portaudio` using `homebrew`
 
 ### using virtualenv (recommend)
-1. `virtualenv virtualassistant.venv`
+1. `virtualenv voiceassistant.venv`
 2. `source voiceassistant.venv/bin/activate`
 
 ### pip packages


### PR DESCRIPTION
…on. The created environment and activated environment had different names