### PR TITLE
Update split_commonvoice.py

### DIFF
--- a/VoiceAssistant/wakeword/scripts/split_commonvoice.py
+++ b/VoiceAssistant/wakeword/scripts/split_commonvoice.py
@@ -18,7 +18,7 @@ def main(args):
         chunks = make_chunks(audio, length)
         names = []
         for i, chunk in enumerate(chunks):
-            _name = file.split(".mp3")[0] + ".wav"
+            _name = file.split(".")[0] + ".wav"
             name = "{}_{}".format(i, _name)
             wav_path = os.path.join(args.save_path, name)
             chunk.export(wav_path, format="wav")


### PR DESCRIPTION
Mostly a question since I cannot check it now as I'm currently lying in bed. I changed split at ".mp3" to split at ".". I have done something similar in my script. This would prevent something like the thing done by happy slice where he used multiple scripts that should technically not be used this way and ended up with a .wav.wav file ending. He first converted to wav then used split_commonvoice as he was not aware that it already converted as well. If this code would split the name at the point and not the whole ending even if you rerun it multiple times it will not be .wav.wav.wav.wav. I'm however not sure if just changing it to a dot would be the correct Syntax and work