### PR TITLE
Bump tensorflow to 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,8 @@ SoundFile==0.10.3.post1
 tabulate==0.8.7
 tensorboard==2.4.0
 tensorboard-plugin-wit==1.7.0
-tensorflow==2.3.0
+tensorflow==2.4.1
+tensorflow==2.5.0
 tensorflow-estimator==2.3.0
 tokenizers==0.9.4
 torch==1.7.1


### PR DESCRIPTION
Update tensorflow to 2.4.1 and added tensorflow 2.5.0 as backup. pypi lists 2.4.1 but I could only install 2.5.0