### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TODO:
 
 ## Running on native machine
 ### dependencies
-* python3
+* python3  (Required Python Libraries are only compatible with Python versions >3.5 and <3.9)
 * portaudio (for recording with pyaudio to work)
 * [ctcdecode](https://github.com/parlance/ctcdecode) - for speechrecognition
 
@@ -24,6 +24,7 @@ If you're on mac you can install `portaudio` using `homebrew`
 **NOTICE: If you are using windows, some things may not work. For example, torchaudio. I suggest trying this on linux or mac, or use wsl2 on windows**
 
 ### using virtualenv (recommend)
+(Virtualenv is highly recommended because libraries in requirements.txt file only support Python <3.9)
 1. `virtualenv voiceassistant.venv`
 2. `source voiceassistant.venv/bin/activate`
 


### PR DESCRIPTION
My system Python is version 3.9.4. This led to me having issues installing several of the libraries in requirements.txt. This happened because the mentioned versions of several libraries only support Python up-to version 3.8.x (mine was 3.9+).
Naturally, virtualenv is the best solution to this.
Since most of the Python users use the latest version, they should be up updated about this.